### PR TITLE
Fix mangled hyphen

### DIFF
--- a/PowerShell/PSService.ps1
+++ b/PowerShell/PSService.ps1
@@ -980,7 +980,7 @@ if ($Service) {                 # Run the service
     Log "$scriptName -Service # Error at line ${line}: $msg"
   } finally { # Invoked in all cases: Exception or normally by -Stop
     # Cleanup the periodic timer used in the above example
-    Unregister-Event –SourceIdentifier $timerName
+    Unregister-Event -SourceIdentifier $timerName
     $timer.stop()
     ############### End of the service code example. ################
     # Terminate the control pipe handler thread


### PR DESCRIPTION
Instead of the hyphen there was a Windows CP-1252 en dash (character 96) in the line I changed.