### PR TITLE
Added execution policy bypass flag to PSService.

### DIFF
--- a/PowerShell/PSService.ps1
+++ b/PowerShell/PSService.ps1
@@ -81,6 +81,7 @@
 #                   use it for the service registration.                      #
 #                   Added comments about Windows event logs limitations.      #
 #    2016-11-17 RBM Fixed issue #6 Mangled hyphen in final Unregister-Event.  #
+#    2017-05-10 CJG Added execution policy bypass flag.                       #
 #                                                                             #
 ###############################################################################
 #Requires -version 2
@@ -183,7 +184,7 @@ Param(
   [Switch]$Version              # Get this script version
 )
 
-$scriptVersion = "2016-11-17"
+$scriptVersion = "2017-05-10"
 
 # This script name, with various levels of details
 $argv0 = Get-Item $MyInvocation.MyCommand.Definition
@@ -701,7 +702,7 @@ $source = @"
         p.StartInfo.UseShellExecute = false;
         p.StartInfo.RedirectStandardOutput = true;
         p.StartInfo.FileName = "PowerShell.exe";
-        p.StartInfo.Arguments = "-c & '$scriptCopyCname' -Start"; // Works if path has spaces, but not if it contains ' quotes.
+        p.StartInfo.Arguments = "-ExecutionPolicy Bypass -c & '$scriptCopyCname' -Start"; // Works if path has spaces, but not if it contains ' quotes.
         p.Start();
         // Read the output stream first and then wait. (To avoid deadlocks says Microsoft!)
         string output = p.StandardOutput.ReadToEnd();


### PR DESCRIPTION
Hi ,
This patch fixes a situation where a certain configuration of execution policy can lead to difficult to diagnose failures.

If the execution policy for CurrentUser allows for execution but LocalMachine doesn't then you can get into the situation where PSServer will successfully install but will fail when attempting to start. PSService.exe, which is run as SYSTEM as it is executed by SCM, attempts to execute PSService.ps1 but fails. Unfortunately you do not get a clear reason as to why it fails, "The application was unable to start correctly", and since the PSService successfully installs you might think, like I did, that the execution policy isn't the issue and then spend a few hours trying to work out what's actually wrong. Adding "-ExecutionPolicy bypass" to the arguments that PSService.exe uses to call PSService.ps1 removes this issue. 

While bypassing the execution policy in this situation is perfectly "legal" it's possibly not ideal as it overrides the policy rather than failing with clear directions as to what is wrong. But as far as I can tell you cant easily see what error PowerShell threw.

Also this pretty much my first pull request so go easy on me but if I could have done something better please do point it out :) I've tired to follow the best advice I can find. Apologies if I've missed anything.

Cheers,
Callum
